### PR TITLE
🤽📖 add Bounty process definition

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.md
+++ b/.github/ISSUE_TEMPLATE/bounty.md
@@ -1,0 +1,53 @@
+---
+name: Bounty
+about: Bounty
+title: ''
+labels: bounty
+assignees: ''
+
+---
+
+# Bounty
+
+## Scope
+<!-- A list of specific things which should be done to deliver the bounty. These could be seen as requirements to verify/review bounty against -->
+
+-
+-
+-
+
+## Deliverables
+<!-- Artifacts produced as the result of this bounty. Something that could be verified/reviewed. Some examples: updated code, deployment made, blog post published, public event conducted etc -->
+
+-
+-
+
+## Funding Circle
+<!-- The Circle to fund this bounty -->
+
+## Bounty Owner/Gardener
+<!-- The Role who is responsible for the bounty. The Role must belong to Funding Circle. -->
+<@your github username> as **<Role>**
+
+## Gain for the Role
+<!-- How the completion of this bounty helps to pursue the Role's purpose -->
+
+## Roles
+bounty gardener: <@your github username> / X DAI <!-- likely shouldn't be a % but rather flat -->
+bounty worker: name / share
+bounty reviewer: name / share
+
+## Gardener checklist
+
+- [ ] I have attached one of the `size-` labels to this bounty
+- [ ] I have submitted this bounty via http://bounty.leapdao.org/viewform
+- [ ] I have added this bounty to bounty board here https://github.com/orgs/leapdao/projects/6
+
+<!--
+# Bounty sizes
+XS / 200 DAI / effort ~ 3h
+S / 350 DAI / effort ~5h 
+M / 550 DAI / effort ~8h
+L / 900 DAI / effort ~13h
+XL / 1400 DAI / effort ~21h
+-->

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -92,6 +92,10 @@ In the cases where objector and proposer are not able to come to an acceptable s
 
 If the tension was integrated successfully or if there weren’t any public objections, the bounty is considered approved.
 
+## Expiration
+
+All non-taken bounties older than 1 month (time of submission through bounty form), MUST be submitted to bounty form again and undergo a new round of objections (as defined in by this spec) before the work can be started on it.
+
 ## Work on Bounty
 
 ### Gardener
@@ -103,7 +107,7 @@ Gardener is expected to:
 * find a Worker for the Bounty
 * help the Worker to understand the scope of the Bounty
 * find a Reviewer for the Bounty.
-* ensure the Bounty doesn’t get stalled
+* ensure the Bounty doesn’t get stalled (see "Expiration" section)
 * request the payout for the Bounty once it is done and reviewed (see "Payout" section below)
 
 ### Worker

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -151,9 +151,13 @@ Reviewer is expected to:
 
 ## Challenging bounties
 
-If bounty has no progress for 4 days, then anyone can challenge the bounty.
+Gardener/Worker/Reviewer roles may be taken over by other people in a certain situations (see below). Each takeover must be stated in written form in corresponding Github issue including new assignee and the reason for takeover.
 
-Once the bounty is challenged, the worker has 3 more days to deliver some progress on the bounty (Gardener can make exception and extend period to 5 days 1x, unless Gardener is also working). If Worker fails to make progress within period, the bounty is up for grabs by anyone.
+### Challenging worker and reviewer
+If worker or reviewer are not publishing any updates for the bounty for 2 working days, then anyone can challenge him and take over the worker role. Updates for worker role can be in any form, most notably: commits to WIP Pull Request, updates on product artifact (hackmd, presentation, diagram etc), review comments, updates in form of github comments or slack conversations.
+
+### Challenging gardener
+If gardener is not helping worker to find a reviewer or doesn't address worker's questions within 2 days, then anyone can challenge him and take over a gardener role on the bounty.
 
 ## Payout
 

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -173,4 +173,4 @@ It is Gardener's duty to request the payout once the bounty is completed and rev
 
 ## Links
 
-* [Bounty issue template](https://github.com/leapdao/leap-node/blob/master/.github/ISSUE_TEMPLATE/bounty.md)
+* [Bounty issue template](https://github.com/leapdao/meta/blob/master/.github/ISSUE_TEMPLATE/bounty.md)

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -1,30 +1,162 @@
-# Bounty definition
+# Rewarding the Roles using Bounties
 
-This policy allows to write out rewards to complete required tasks. Completed tasks are payed by the Escrow council to the claiming member.
+* [Glossary](#glossary)
+* [Bounty definition](#bounty-definition)
+  * [Title](#title)
+  * [Scope](#scope)
+  * [Deliverables](#deliverables)
+  * [Funding Circle](#funding-circle)
+  * [Bounty owner/gardener](#bounty-ownergardener)
+  * [Gain for the Role](#gain-for-the-role)
+  * [Size](#size)
+* [Who can create a new bounty](#who-can-create-a-new-bounty)
+* [How to create a new bounty](#how-to-create-a-new-bounty)
+* [Pair bounty](#pair-bounty)
+* [Objecting bounties](#objecting-bounties)
+* [Work on Bounty](#work-on-bounty)
+  * [Gardener](#gardener)
+  * [Worker](#worker)
+  * [Reviewer](#reviewer)
+* [Challenging bounties](#challenging-bounties)
+* [Links](#links)
 
-How to create a new bounty?
-Create an issue with bounty description and a bounty tag in an appropriate repository.
-If the bounty spans across multiple repositories, consider splitting it in a smaller per-repo bounties if possible.
-If the bounty is larger than M, then the best known expert in the bounty matter should be consulted and included in an "Expert" field in the bounty description.
-Submit proposal via the bounty form: http://bounty.leapdao.org/viewform
-Add the bounty to the bounties board: https://github.com/orgs/leapdao/projects/6
+## Glossary
 
-Objections:
-Any bounty can be objected by anyone through Slack or GitHub for 2 days after its creation.
-The objector must ensure that their objection is clearly communicated to the bounty proposer and e.g. not misunderstood as a minor comment on the issue.
-In the cases where objector and proposer are not able to come to an acceptable solution, the circle’s facilitator must be involved to enact Holacracy constitution’s article “3.3.5 INTEGRATIVE DECISION-MAKING PROCESS” to solve the objection as a tension.
+[Role](https://www.holacracy.org/constitution#art11), [Action](https://www.holacracy.org/constitution#art122), [Project](https://www.holacracy.org/constitution#art122) and [Circle](https://www.holacracy.org/constitution#art21) are all concepts defined in Holacracy Constitution.
+
+## Bounty definition
+
+Bounty is a reward for completing a properly defined Action or Project within a Circle. For simplicity, we will may call such Actions or Projects themselves a Bounties from now on.
+
+Properly defined bounty must specify the following attributes
+
+### Title
+
+Succinct name for the bounty.
+
+Example:
+> Implement Basic Token Governance UI
+
+### Scope
+
+A list of specific things which should be done to deliver the bounty. These could be seen as requirements to verify/review bounty against.
+
+### Deliverables
+
+Artifacts produced as the result of this bounty. Something that could be verified/reviewed. Some examples: updated code, deployment made, blog post published, public event conducted etc
+
+### Funding Circle
+
+The Circle to fund this bounty
+
+### Bounty owner/gardener
+
+The Role who is responsible for the bounty. The Role should belong to Funding Circle.
+
+### Gain for the Role
+
+How the completion of this bounty helps to pursue the Role's purpose
+
+### Size
+
+Size of the bounty.
+
+We use t-shirt sizes:
+
+* XS. 200 DAI
+* S. 350 DAI
+* M. 550 DAI
+* L. 900 DAI
+* XL. 1400 DAI
+
+## Who can create a new bounty
+
+Any Role within the Organization. People without Roles may also propose a bounty on behalf of some Role.
+
+## How to create a new bounty
+
+1. Create a Github issue with properly defined bounty description (see above) in an appropriate repository.
+2. If the bounty spans across multiple repositories, consider splitting it in a smaller per-repo bounties if possible or put in `leapdao/meta` repository.
+3. Submit proposal via the [bounty form](http://bounty.leapdao.org/viewform)
+4. Add the bounty to the [bounties board](https://github.com/orgs/leapdao/projects/6)
+
+## Pair bounty
+
+If two people work on the bounty together, the payout increases by 1.5x.
+
+## Objecting bounties
+
+Any bounty can be objected by anyone through Slack or GitHub for 2 days after its creation. A valid objection should describe how the bounty is not helping bounty Role to achieve it's purpose or how the bounty is harming the Organization. The objector must ensure that their objection is clearly communicated to the bounty proposer and e.g. not misunderstood as a minor comment on the issue.
+
+In the cases where objector and proposer are not able to come to an acceptable solution, the Circle’s facilitator must be involved to enact Integrative Decision-Making Process as specified in Holacracy constitution ([§1.3.5](https://www.holacracy.org/constitution#art135)) to solve the objection as a tension.
+
 If the tension was integrated successfully or if there weren’t any public objections, the bounty is considered approved.
-Bounty sizes
-XS	200
-S	350
-M	550
-L	900
-XL	1400
 
-Pair programming
-If 2 people work on the bounty together, the payout increases by 1.5x.
+## Work on Bounty
 
-Bounty Challenge
-If bounty has no progress for 4 days, then anyone can challenge the bounty. Once the bounty is challenged, the worker has 3 more days to deliver some progress on the bounty (gardener can make exception and extend period to 5 days 1x, unless gardener is also working). If worker fails to make progress within period, the bounty is up for grabs by anyone.
+### Gardener
 
-Template: https://github.com/leapdao/leap-node/blob/master/.github/ISSUE_TEMPLATE.md
+Gardener is the one who creates the bounty and is responsible for it's completion.
+
+Gardener is expected to:
+
+* find a Worker for the Bounty
+* help the Worker to understand the scope of the Bounty
+* find a Reviewer for the Bounty.
+* ensure the Bounty doesn’t get stalled
+* request the payout for the Bounty once it is done and reviewed. Payout is requested on Slack in a Circle's channel like this:
+  > 🌴💰 Requesting payout for **\<bounty title\>** \
+  > Issue: \<link to the Bounty on Github\> \
+  > Product: \<link to deliverable, e.g. PR or writeup\> \
+  > gardener: \<@gardener\> \<gardener share\> \
+  > worker: \<@worker\> \<worker share\> \
+  > reviewer: \<@reviewer\> \<reviewer share\>
+
+### Worker
+
+Worker is the one who actually implements the Bounty.
+
+Worker is expected to:
+
+* create WIP Pull Request within 4 days from the start of the bounty (if applicable)
+* actively work on the Bounty according to it's Scope, don't linger (see "Challenging bounties" section below)
+* stay accountable by publishing WIP updates at least every 2 working days:
+  * for coding bounties, the Worker is expected to push commits in WIP Pull Request.
+  * for writeups, the Worker is expected to share a draft Hackmd document (or other meidum of his choice) he is working at.
+* request a review once the work is done. Review is requested on Slack in a Circle's channel like this:
+  > 🌴👀 Requesting review for **\<bounty title\>** \
+  > Issue: \<link to the Bounty on Github\> \
+  > Product: \<link to deliverable, e.g. PR or writeup\>
+
+### Reviewer
+
+Reviewer is the person who reviews the Bounty's deliverables.
+
+Reviewer is expected to:
+
+* do review in timely manner, don't linger (see "Challenging bounties" section below)
+* ensure all the delivables are provided
+* ensure all the Scope items are addressed
+* for coding bounties:
+  * make sure the code is compiling/building correctly
+  * review the code for logical correctness, inefficiencies and style (TBD)
+  * ensure unit tests are passing
+  * ensure code coverage is not reduced
+  * ensure integration tests are passing for the PR branch
+* for public writeups
+  * do fact check
+  * check readability
+  * correct grammar and punctuation
+  * check social network preview e.g. twitter card (if applicable)
+* forward all the issues found publicly to the Worker (e.g. as comments on Github)
+* approve the PR once the review is complete successfuly (if applicable)
+
+## Challenging bounties
+
+If bounty has no progress for 4 days, then anyone can challenge the bounty.
+
+Once the bounty is challenged, the worker has 3 more days to deliver some progress on the bounty (Gardener can make exception and extend period to 5 days 1x, unless Gardener is also working). If Worker fails to make progress within period, the bounty is up for grabs by anyone.
+
+## Links
+
+* [Bounty issue template](https://github.com/leapdao/leap-node/blob/master/.github/ISSUE_TEMPLATE/bounty.md)

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -104,13 +104,7 @@ Gardener is expected to:
 * help the Worker to understand the scope of the Bounty
 * find a Reviewer for the Bounty.
 * ensure the Bounty doesn’t get stalled
-* request the payout for the Bounty once it is done and reviewed. Payout is requested on Slack in a Circle's channel like this:
-  > 🌴💰 Requesting payout for **\<bounty title\>** \
-  > Issue: \<link to the Bounty on Github\> \
-  > Product: \<link to deliverable, e.g. PR or writeup\> \
-  > gardener: \<@gardener\> \<gardener share\> \
-  > worker: \<@worker\> \<worker share\> \
-  > reviewer: \<@reviewer\> \<reviewer share\>
+* request the payout for the Bounty once it is done and reviewed (see "Payout" section below)
 
 ### Worker
 
@@ -156,6 +150,18 @@ Reviewer is expected to:
 If bounty has no progress for 4 days, then anyone can challenge the bounty.
 
 Once the bounty is challenged, the worker has 3 more days to deliver some progress on the bounty (Gardener can make exception and extend period to 5 days 1x, unless Gardener is also working). If Worker fails to make progress within period, the bounty is up for grabs by anyone.
+
+## Payout
+
+Funds allocated for bounty are split between Gardener, Worker and Reviewer in a proportion defined by Gardener (can be negotiated).
+
+It is Gardener's duty to request the payout once the bounty is completed and reviewed. Payout is requested on Slack in a Circle's channel like this:
+  > 🌴💰 Requesting payout for **\<bounty title\>** \
+  > Issue: \<link to the Bounty on Github\> \
+  > Product: \<link to deliverable, e.g. PR or writeup\> \
+  > gardener: \<@gardener\> \<gardener share\> \
+  > worker: \<@worker\> \<worker share\> \
+  > reviewer: \<@reviewer\> \<reviewer share\>
 
 ## Links
 

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -39,7 +39,7 @@ Example:
 
 ### Scope
 
-A list of specific things which should be done to deliver the bounty. These could be seen as requirements to verify/review bounty against.
+A list of specific things which should be done to deliver the bounty. These could be seen as requirements to verify/review the bounty against.
 
 ### Deliverables
 
@@ -55,7 +55,7 @@ The Role who is responsible for the bounty. The Role should belong to Funding Ci
 
 ### Gain for the Role
 
-How the completion of this bounty helps to pursue the Role's purpose
+How the completion of this bounty helps to pursue the Role's purpose.
 
 ### Size
 
@@ -63,11 +63,11 @@ Size of the bounty.
 
 We use t-shirt sizes:
 
-* XS. 200 DAI
-* S. 350 DAI
-* M. 550 DAI
-* L. 900 DAI
-* XL. 1400 DAI
+* size-XS: 200 DAI
+* size-S: 350 DAI
+* size-M: 550 DAI
+* size-L: 900 DAI
+* size-XL: 1400 DAI
 
 ## Who can create a new bounty
 
@@ -88,7 +88,7 @@ If two people work on the bounty together, the payout increases by 1.5x.
 
 Any bounty can be objected by anyone through Slack or GitHub for 2 days after its creation. A valid objection should describe how the bounty is not helping bounty Role to achieve it's purpose or how the bounty is harming the Organization. The objector must ensure that their objection is clearly communicated to the bounty proposer and e.g. not misunderstood as a minor comment on the issue.
 
-In the cases where objector and proposer are not able to come to an acceptable solution, the Circle’s facilitator must be involved to enact Integrative Decision-Making Process as specified in Holacracy constitution ([§1.3.5](https://www.holacracy.org/constitution#art135)) to solve the objection as a tension.
+In the cases where objector and proposer are not able to come to an acceptable solution, the Circle’s facilitator must be involved to enact Integrative Decision-Making Process as specified in Holacracy constitution ([§3.3.5](https://www.holacracy.org/constitution#art335)) to solve the objection as a tension.
 
 If the tension was integrated successfully or if there weren’t any public objections, the bounty is considered approved.
 
@@ -104,11 +104,11 @@ Gardener is the one who creates the bounty and is responsible for it's completio
 
 Gardener is expected to:
 
-* find a Worker for the Bounty
-* help the Worker to understand the scope of the Bounty
+* find a Worker for the Bounty.
+* help the Worker to understand the scope of the Bounty.
 * find a Reviewer for the Bounty.
-* ensure the Bounty doesn’t get stalled (see "Expiration" section)
-* request the payout for the Bounty once it is done and reviewed (see "Payout" section below)
+* ensure the Bounty doesn’t get stalled (see "Expiration" section).
+* request the payout for the Bounty once it is done and reviewed (see "Payout" section below).
 
 ### Worker
 

--- a/playbook/bounties.md
+++ b/playbook/bounties.md
@@ -1,0 +1,30 @@
+# Bounty definition
+
+This policy allows to write out rewards to complete required tasks. Completed tasks are payed by the Escrow council to the claiming member.
+
+How to create a new bounty?
+Create an issue with bounty description and a bounty tag in an appropriate repository.
+If the bounty spans across multiple repositories, consider splitting it in a smaller per-repo bounties if possible.
+If the bounty is larger than M, then the best known expert in the bounty matter should be consulted and included in an "Expert" field in the bounty description.
+Submit proposal via the bounty form: http://bounty.leapdao.org/viewform
+Add the bounty to the bounties board: https://github.com/orgs/leapdao/projects/6
+
+Objections:
+Any bounty can be objected by anyone through Slack or GitHub for 2 days after its creation.
+The objector must ensure that their objection is clearly communicated to the bounty proposer and e.g. not misunderstood as a minor comment on the issue.
+In the cases where objector and proposer are not able to come to an acceptable solution, the circle’s facilitator must be involved to enact Holacracy constitution’s article “3.3.5 INTEGRATIVE DECISION-MAKING PROCESS” to solve the objection as a tension.
+If the tension was integrated successfully or if there weren’t any public objections, the bounty is considered approved.
+Bounty sizes
+XS	200
+S	350
+M	550
+L	900
+XL	1400
+
+Pair programming
+If 2 people work on the bounty together, the payout increases by 1.5x.
+
+Bounty Challenge
+If bounty has no progress for 4 days, then anyone can challenge the bounty. Once the bounty is challenged, the worker has 3 more days to deliver some progress on the bounty (gardener can make exception and extend period to 5 days 1x, unless gardener is also working). If worker fails to make progress within period, the bounty is up for grabs by anyone.
+
+Template: https://github.com/leapdao/leap-node/blob/master/.github/ISSUE_TEMPLATE.md


### PR DESCRIPTION

## What's in this PR

Main change here is that Bounty is no longer expected to be "aligned with the project" but rather proposed out of one of the Roles in LeapDAO Holacracy Org.

Outline of specific changes done here:
- extracted Bounty Specification from Bounty Policy
- added Gardener/Worker/Reviewer descriptions from [Onboarding wiki](https://github.com/leapdao/meta/wiki/Onboarding)
- added expectations for Gardener/Worker/Reviewer
- new Bounty issue template:
  - replaced "Gain for the project" with "Gain for the Role"
  - added "Bounty Owner/Gardener" section to explicitly specify who is responsible for the Bounty
  - removed "Publicly visible delivery" (not used)
  - removed "Expert" (not used)
  - added "Funding Circle" to specify which circle should fund the bounty
  - added checklist for the gardener
